### PR TITLE
Updated ECM Jammer timer for U104

### DIFF
--- a/JackHUD/Lua/HUDManagerPD2_ext.lua
+++ b/JackHUD/Lua/HUDManagerPD2_ext.lua
@@ -2599,10 +2599,17 @@ do
 	HUDList.ECMItem = HUDList.ECMItem or class(HUDList.ItemBase)
 	function HUDList.ECMItem:init(parent, name)
 		HUDList.ItemBase.init(self, parent, name, { align = "right", w = parent:panel():h(), h = parent:panel():h() })
-
-		self._max_duration = tweak_data.upgrades.ecm_jammer_base_battery_life *
-			tweak_data.upgrades.values.ecm_jammer.duration_multiplier[1] *
-			tweak_data.upgrades.values.ecm_jammer.duration_multiplier_2[1]
+		
+		battery_upgrade_level = 1
+		if tweak_data.upgrades.values.ecm_jammer.duration_multiplier[1] then
+			battery_upgrade_level = battery_upgrade_level + 1
+		end
+		
+		if tweak_data.upgrades.values.ecm_jammer.duration_multiplier_2[1] then
+			battery_upgrade_level = battery_upgrade_level + 1
+		end
+		
+		self._max_duration = tweak_data.upgrades.ecm_jammer_base_battery_life * ECMJammerBase.battery_life_multiplier[battery_upgrade_level]
 
 		self._box = HUDBGBox_create(self._panel, {
 				w = self._panel:w(),

--- a/JackHUD/Lua/HUDManagerPD2_ext.lua
+++ b/JackHUD/Lua/HUDManagerPD2_ext.lua
@@ -2600,14 +2600,7 @@ do
 	function HUDList.ECMItem:init(parent, name)
 		HUDList.ItemBase.init(self, parent, name, { align = "right", w = parent:panel():h(), h = parent:panel():h() })
 		
-		battery_upgrade_level = 1
-		if tweak_data.upgrades.values.ecm_jammer.duration_multiplier[1] then
-			battery_upgrade_level = battery_upgrade_level + 1
-		end
-		
-		if tweak_data.upgrades.values.ecm_jammer.duration_multiplier_2[1] then
-			battery_upgrade_level = battery_upgrade_level + 1
-		end
+		battery_upgrade_level = managers.player:upgrade_level("ecm_jammer", "duration_multiplier", 0) + managers.player:upgrade_level("ecm_jammer", "duration_multiplier_2", 0) + 1
 		
 		self._max_duration = tweak_data.upgrades.ecm_jammer_base_battery_life * ECMJammerBase.battery_life_multiplier[battery_upgrade_level]
 


### PR DESCRIPTION
U104 changed the ECM upgrades to boolean values.
New code checks boolean values for upgrade level,
then selects multiplier from ECMJammerBase based
on number of upgrades.
