### PR TITLE
Add shotgun support for remember gadget state

### DIFF
--- a/JackHUD/JackHUD.lua
+++ b/JackHUD/JackHUD.lua
@@ -69,6 +69,7 @@ if not JackHUD.setup then
 		["lib/units/props/securitycamera"] = "SecurityCamera_ext.lua",
 		["lib/units/props/timergui"] = "TimerGui_ext.lua",
 		["lib/units/weapons/newraycastweaponbase"] = "NewRayCastWeaponBase_ext.lua",
+		["lib/units/weapons/shotgun/newshotgunabse"] = "NewShotgunBase_ext.lua",
 		["lib/units/weapons/raycastweaponbase"] = "RayCastWeaponBase_ext.lua",
 		["lib/units/weapons/sentrygunweapon"] = "SentryGunWeapon_ext.lua",
 		["lib/units/weapons/weaponflashlight"] = "WeaponFlashlight_ext.lua",

--- a/JackHUD/Lua/HUDManagerPD2_ext.lua
+++ b/JackHUD/Lua/HUDManagerPD2_ext.lua
@@ -2599,10 +2599,17 @@ do
 	HUDList.ECMItem = HUDList.ECMItem or class(HUDList.ItemBase)
 	function HUDList.ECMItem:init(parent, name)
 		HUDList.ItemBase.init(self, parent, name, { align = "right", w = parent:panel():h(), h = parent:panel():h() })
-
-		self._max_duration = tweak_data.upgrades.ecm_jammer_base_battery_life *
-			tweak_data.upgrades.values.ecm_jammer.duration_multiplier[1] *
-			tweak_data.upgrades.values.ecm_jammer.duration_multiplier_2[1]
+		
+		battery_upgrade_level = 1
+		if tweak_data.upgrades.values.ecm_jammer.duration_multiplier[1] then
+			battery_upgrade_level = battery_upgrade_level + 1
+		end
+		
+		if tweak_data.upgrades.values.ecm_jammer.duration_multiplier_2[1] then
+			battery_upgrade_level = battery_upgrade_level + 1
+		end
+		
+		self._max_duration = tweak_data.upgrades.ecm_jammer_base_battery_life * ECMJammerBase.battery_life_multiplier[battery_upgrade_level]
 
 		self._box = HUDBGBox_create(self._panel, {
 				w = self._panel:w(),

--- a/JackHUD/Lua/HUDManagerPD2_ext.lua
+++ b/JackHUD/Lua/HUDManagerPD2_ext.lua
@@ -2600,14 +2600,7 @@ do
 	function HUDList.ECMItem:init(parent, name)
 		HUDList.ItemBase.init(self, parent, name, { align = "right", w = parent:panel():h(), h = parent:panel():h() })
 		
-		battery_upgrade_level = 1
-		if tweak_data.upgrades.values.ecm_jammer.duration_multiplier[1] then
-			battery_upgrade_level = battery_upgrade_level + 1
-		end
-		
-		if tweak_data.upgrades.values.ecm_jammer.duration_multiplier_2[1] then
-			battery_upgrade_level = battery_upgrade_level + 1
-		end
+		battery_upgrade_level = managers.player:upgrade_level("ecm_jammer", "duration_multiplier", 0) + managers.player:upgrade_level("ecm_jammer", "duration_multiplier_2", 0) + 1
 		
 		self._max_duration = tweak_data.upgrades.ecm_jammer_base_battery_life * ECMJammerBase.battery_life_multiplier[battery_upgrade_level]
 

--- a/JackHUD/Lua/NewShotgunBase_ext.lua
+++ b/JackHUD/Lua/NewShotgunBase_ext.lua
@@ -1,0 +1,13 @@
+local toggle_gadget_original = NewRaycastWeaponBase.toggle_gadget
+function NewRaycastWeaponBase:toggle_gadget()
+	if toggle_gadget_original(self) then
+		self._stored_gadget_on = self._gadget_on
+		return true
+	end
+end
+
+local on_equip_original = NewShotgunBase.on_equip
+function NewShotgunBase:on_equip(user_unit, ...)
+	on_equip_original(self, user_unit, ...)
+	self:set_gadget_on(JackHUD:GetOption("remember_gadget_state") and self._stored_gadget_on or 0, false)
+end

--- a/JackHUD/mod.txt
+++ b/JackHUD/mod.txt
@@ -61,6 +61,7 @@
 		{"script_path" : "JackHUD.lua", "hook_id" : "lib/units/props/securitycamera"},
 		{"script_path" : "JackHUD.lua", "hook_id" : "lib/units/props/timergui"},
 		{"script_path" : "JackHUD.lua", "hook_id" : "lib/units/weapons/newraycastweaponbase"},
+		{"script_path" : "JackHUD.lua", "hook_id" : "lib/units/weapons/shotgun/newshotgunbase"},
 		{"script_path" : "JackHUD.lua", "hook_id" : "lib/units/weapons/raycastweaponbase"},
 		{"script_path" : "JackHUD.lua", "hook_id" : "lib/units/weapons/sentrygunweapon"},
 		{"script_path" : "JackHUD.lua", "hook_id" : "lib/units/weapons/weaponflashlight"},


### PR DESCRIPTION
Fix uses code from NewRayCastWeaponBase_ext.lua, simply reworded to support NewShotgunBase's override of on_equip.
