### PR TITLE
Add shotgun support to gadget-state

### DIFF
--- a/JackHUD/JackHUD.lua
+++ b/JackHUD/JackHUD.lua
@@ -69,6 +69,7 @@ if not JackHUD.setup then
 		["lib/units/props/securitycamera"] = "SecurityCamera_ext.lua",
 		["lib/units/props/timergui"] = "TimerGui_ext.lua",
 		["lib/units/weapons/newraycastweaponbase"] = "NewRayCastWeaponBase_ext.lua",
+		["lib/units/weapons/shotgun/newshotgunbase"] = "NewShotgunBase_ext.lua",
 		["lib/units/weapons/raycastweaponbase"] = "RayCastWeaponBase_ext.lua",
 		["lib/units/weapons/sentrygunweapon"] = "SentryGunWeapon_ext.lua",
 		["lib/units/weapons/weaponflashlight"] = "WeaponFlashlight_ext.lua",

--- a/JackHUD/Lua/NewShotgunBase_ext.lua
+++ b/JackHUD/Lua/NewShotgunBase_ext.lua
@@ -1,0 +1,13 @@
+local toggle_gadget_original = NewRaycastWeaponBase.toggle_gadget
+function NewRaycastWeaponBase:toggle_gadget()
+	if toggle_gadget_original(self) then
+		self._stored_gadget_on = self._gadget_on
+		return true
+	end
+end
+
+local on_equip_original = NewShotgunBase.on_equip
+function NewShotgunBase:on_equip(user_unit, ...)
+	on_equip_original(self, user_unit, ...)
+	self:set_gadget_on(JackHUD:GetOption("remember_gadget_state") and self._stored_gadget_on or 0, false)
+end

--- a/JackHUD/mod.txt
+++ b/JackHUD/mod.txt
@@ -61,6 +61,7 @@
 		{"script_path" : "JackHUD.lua", "hook_id" : "lib/units/props/securitycamera"},
 		{"script_path" : "JackHUD.lua", "hook_id" : "lib/units/props/timergui"},
 		{"script_path" : "JackHUD.lua", "hook_id" : "lib/units/weapons/newraycastweaponbase"},
+		{"script_path" : "JackHUD.lua", "hook_id" : "lib/units/weapons/shotgun/newshotgunbase"},
 		{"script_path" : "JackHUD.lua", "hook_id" : "lib/units/weapons/raycastweaponbase"},
 		{"script_path" : "JackHUD.lua", "hook_id" : "lib/units/weapons/sentrygunweapon"},
 		{"script_path" : "JackHUD.lua", "hook_id" : "lib/units/weapons/weaponflashlight"},


### PR DESCRIPTION
Uses code from NewRayCastWeaponBase_ext.lua slightly modified to support
NewShotgunBase.lua's override of on_equip. Otherwise identical to
NewRayCastWeaponBase_ext.lua; new file for consistency's sake.
