### PR TITLE
Laser fix for shotguns

### DIFF
--- a/JackHUD/Lua/NewShotgunBase_ext.lua
+++ b/JackHUD/Lua/NewShotgunBase_ext.lua
@@ -1,4 +1,5 @@
 local toggle_gadget_original = NewRaycastWeaponBase.toggle_gadget
+
 function NewRaycastWeaponBase:toggle_gadget()
 	if toggle_gadget_original(self) then
 		self._stored_gadget_on = self._gadget_on
@@ -7,7 +8,24 @@ function NewRaycastWeaponBase:toggle_gadget()
 end
 
 local on_equip_original = NewShotgunBase.on_equip
+
 function NewShotgunBase:on_equip(user_unit, ...)
-	on_equip_original(self, user_unit, ...)
+	if self._has_gadget then
+		self:_setup_laser()
+		if alive(self._second_gun) then
+			self._second_gun:base():_setup_laser()
+		end
+	end
+
 	self:set_gadget_on(JackHUD:GetOption("remember_gadget_state") and self._stored_gadget_on or 0, false)
+	return on_equip_original(self, user_unit, ...)
+end
+
+function NewShotgunBase:_setup_laser()
+	for _, part in pairs(self._parts) do
+		local base = part.unit and part.unit:base()
+		if base and base.set_color_by_theme then
+			base:set_color_by_theme("player")
+		end
+	end
 end


### PR DESCRIPTION
Same fix as applied to shotguns for gadget state.

Copied code from RaycastWeaponBase_ext.lua to support NewShotgunBase's overriding of on_equip. Shotguns will now properly set their laser theme to "player" on equip, resulting in expected behavior from custom laser color settings. Previously, settings for "other" lasers would be applied, if active, due to player lasers' automatic use of the "default" theme.
